### PR TITLE
feat: add scope-aware handling for notes

### DIFF
--- a/lua/doodle/config.lua
+++ b/lua/doodle/config.lua
@@ -1,3 +1,5 @@
+local Job = require("plenary.job")
+
 ---@field DoodleOperations
 local DoodleConfig = {}
 
@@ -7,15 +9,24 @@ function DoodleConfig.get_default()
 	    auto_save = true,
 	    project = function ()
 		return vim.loop.cwd()
+	    end,
+	    branch = function ()
+		return Job:new({
+		    command = "git",
+		    args = { "rev-parse", "--abbrev-ref", "HEAD" },
+		}):sync()[1]
+	    end,
+	    global = function ()
+		return "__global"
 	    end
 	},
 	operations = {
 	    encode = function (obj)
-	    	return vim.json.encode(obj)
+		return vim.json.encode(obj)
 	    end,
 
 	    decode = function (str)
-	    	return vim.json.decode(str)
+		return vim.json.decode(str)
 	    end,
 
 

--- a/lua/doodle/note.lua
+++ b/lua/doodle/note.lua
@@ -1,10 +1,11 @@
-
 ---@class DoodleNote
 local DoodleNote = {}
 DoodleNote.__index = DoodleNote
 
 ---@field branch string
 ---@field body string
+---@field global_note DoodleNote
+---@field branch_note DoodleNote
 ---@field operators DoodleConfig.operators
 ---@return DoodleNote
 function DoodleNote:new(branch, body, operators)
@@ -12,12 +13,32 @@ function DoodleNote:new(branch, body, operators)
     return setmetatable({
 	branch = branch,
 	body = body,
+	global_note = nil,
+	branch_note = nil,
 	operators = operators
     }, self)
 end
 
-function DoodleNote:update(body, length)
+function DoodleNote:update(body)
     self.body = body
+end
+
+function DoodleNote:append(body)
+  if not self.body then
+    self.body = {}
+  end
+  vim.list_extend(self.body, body)
+end
+
+function DoodleNote:display()
+    local display = {}
+    table.insert(display, "")
+    vim.list_extend(display, self.body)
+    return display
+end
+
+function DoodleNote:get_length()
+    return self.body and #self.body or 0
 end
 
 function DoodleNote:get_body()

--- a/lua/doodle/ui.lua
+++ b/lua/doodle/ui.lua
@@ -1,5 +1,9 @@
 local DoodleBuffer = require("doodle.buffer")
 
+local scopes = { "Project", "Branch", "Global" }
+local scope_marks = { "P", "B", "G" }
+local ns
+
 local DoodleUI = {}
 DoodleUI.__index = DoodleUI
 
@@ -8,17 +12,20 @@ function DoodleUI:new(settings)
 	win_id = nil,
 	bufnr = nil,
 	active_note = nil,
-	setttings = settings
+	branch_note = nil,
+	global_note = nil,
+	current_scope = 1,
+	settings = settings
     }, self)
 end
 
 function DoodleUI:close()
     if self.bufnr ~= nil and vim.api.nvim_buf_is_valid(self.bufnr) then
-        vim.api.nvim_buf_delete(self.bufnr, { force = true })
+	vim.api.nvim_buf_delete(self.bufnr, { force = true })
     end
 
     if self.win_id ~= nil and vim.api.nvim_win_is_valid(self.win_id) then
-        vim.api.nvim_win_close(self.win_id, true)
+	vim.api.nvim_win_close(self.win_id, true)
     end
 
     self.active_list = nil
@@ -27,31 +34,52 @@ function DoodleUI:close()
 end
 
 function DoodleUI:get_ui_content()
-   local body = DoodleBuffer:get_contents(self.bufnr)
-   local length = #body
-   return body, length
+    return DoodleBuffer:get_contents(self.bufnr, ns)
+end
+
+function DoodleUI:get_current_note()
+    if self.current_scope == 1 then
+	return self.active_note
+    elseif self.current_scope == 2 then
+	return self.branch_note
+    else
+	return self.global_note
+    end
 end
 
 function DoodleUI:save()
-    local body, length = self:get_ui_content()
-    self.active_note:update(body, length)
+    local p, b, g, unmarked = self:get_ui_content()
+
+    local current_note = self:get_current_note()
+    current_note:update(unmarked)
+
+    self.active_note:append(p)
+    self.global_note:append(g)
+    if self.branch_note then
+	self.branch_note:append(b)
+    end
 end
 
 function DoodleUI:create_window()
     local width = math.min(math.floor(vim.o.columns * 0.8), 64)
     local height = math.floor(vim.o.lines * 0.8)
 
+    ns = vim.api.nvim_create_namespace("doodle_ns")
+
     local bufnr = vim.api.nvim_create_buf(false, true)
     local win_id = vim.api.nvim_open_win(bufnr, true, {
 	relative = "editor",
-	title = "Doodle",
+	-- title = "Doodle",
+	-- title_pos = "right",
 	row = math.floor(((vim.o.lines - height) / 2) - 1),
 	col = math.floor((vim.o.columns - width) / 2),
-	title_pos = "center",
 	width = width,
 	height = height,
 	style = "minimal",
-	border = "single"
+	border = "solid",
+	footer = "doodle",
+	footer_pos = "right"
+
     })
 
     if win_id == 0 then
@@ -70,6 +98,52 @@ function DoodleUI:create_window()
     return win_id, bufnr
 end
 
+local function render_scope_line(bufnr, current_scope)
+    local virt_text = {}
+    for i, scope in ipairs(scopes) do
+	if i == current_scope then
+	    table.insert(virt_text, { " " .. scope .. " ", "Keyword" })  -- active
+	else
+	    table.insert(virt_text, { " " .. scope .. " ", "Comment" })  -- inactive
+	end
+
+	if i < #scopes then
+	    table.insert(virt_text, { "|", "Comment" })
+	end
+    end
+
+    vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+    vim.api.nvim_buf_set_extmark(bufnr, ns, 0, 0, {
+	virt_text = virt_text,
+	virt_text_pos = "overlay",
+    })
+end
+
+local function draw_virtual_hline(bufnr, win, lnum)
+    local width = vim.api.nvim_win_get_width(win)
+    local line = string.rep("─", width)
+    vim.api.nvim_buf_set_extmark(bufnr, ns, lnum, 0, {
+	virt_text = {{line, "Comment"}},
+	virt_text_pos = "overlay",
+    })
+end
+
+local function render_body(bufnr, win_id, note)
+    vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+    local body = note and note:display(bufnr, win_id) or {"", "<Git repository not found>"}
+    vim.api.nvim_buf_set_lines(bufnr, 1, -1, false, body)
+end
+
+function DoodleUI:render()
+    local note = self:get_current_note()
+    render_body(self.bufnr, self.win_id, note)
+    render_scope_line(self.bufnr, self.current_scope)
+    draw_virtual_hline(self.bufnr, self.win_id, 1)
+    if not note then
+	vim.api.nvim_set_option_value("modifiable", false, { buf = self.bufnr })
+    end
+end
+
 function DoodleUI:toggle_view(note)
     if note == nil or self.win_id ~= nil then
 	self:close()
@@ -81,9 +155,65 @@ function DoodleUI:toggle_view(note)
     self.win_id = win_id
     self.bufnr = bufnr
     self.active_note = note
+    self.global_note = note.global_note
+    self.branch_note = note.branch_note
 
-    local body = self.active_note:get_body() or {}
-    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, body)
+    self:render()
+end
+
+local function mark_scope(bufnr, current_scope, scope_idx, start_row, end_row)
+    if scope_idx ~= current_scope then
+	local mark = scope_marks[scope_idx]
+	for i=start_row, end_row do
+	    vim.api.nvim_buf_set_extmark(bufnr, ns, i-1, 0, {
+		sign_text = mark,
+		sign_hl_group = scope_idx == 1 and "Keyword" or scope_idx == 2 and "Identifier" or "Type",
+	    })
+	end
+    end
+end
+
+local function get_start_and_end_row()
+    local mode = vim.api.nvim_get_mode()["mode"]
+    local start_row
+    local end_row
+
+    if mode == "V" then
+	start_row = vim.fn.getpos("v")[2]
+	end_row = vim.fn.getpos(".")[2]
+    else
+	start_row = vim.api.nvim_win_get_cursor(0)[1]
+	end_row = start_row
+    end
+
+    return start_row, end_row
+end
+
+function DoodleUI:pin_project()
+    if self.active_note == nil or self.win_id == nil or self.bufnr == nil then
+	return
+    end
+
+    local start_row, end_row = get_start_and_end_row()
+    mark_scope(self.bufnr, self.current_scope, 1, start_row, end_row)
+end
+
+function DoodleUI:pin_branch()
+    if self.active_note == nil or self.win_id == nil or self.bufnr == nil then
+	return
+    end
+
+    local start_row, end_row = get_start_and_end_row()
+    mark_scope(self.bufnr, self.current_scope, 2, start_row, end_row)
+end
+
+function DoodleUI:pin_global()
+    if self.active_note == nil or self.win_id == nil or self.bufnr == nil then
+	return
+    end
+
+    local start_row, end_row = get_start_and_end_row()
+    mark_scope(self.bufnr, self.current_scope, 3, start_row, end_row)
 end
 
 return DoodleUI

--- a/lua/doodle/utils/fileutil.lua
+++ b/lua/doodle/utils/fileutil.lua
@@ -1,0 +1,52 @@
+local Path = require("plenary.path")
+local Job = require("plenary.job")
+
+local M = {}
+
+local data_path = string.format("%s/doodle", vim.fn.stdpath("data"))
+local path_exists = false
+
+function M.create_data_path_if_not_exists()
+    if path_exists then
+	return
+    end
+
+    local path = Path:new(data_path)
+    if not path:exists() then
+	path:mkdir()
+    end
+    path_exists = true
+end
+
+---@field project string
+---@return string
+local function hash(str)
+    return vim.fn.sha256(str)
+end
+
+---@field config DoodleConfig
+---@return string
+local function get_filename(str)
+    return hash(str)
+end
+
+---@field config DoodleConfig
+---@return string
+local function get_fullpath(str)
+    local filename = get_filename(str)
+    return string.format("%s/%s", data_path, filename)
+end
+
+function M.getPath(str)
+    local fullpath = get_fullpath(str)
+    return Path:new(fullpath)
+end
+
+function M.get_git_branch()
+  return Job:new({
+    command = "git",
+    args = { "rev-parse", "--abbrev-ref", "HEAD" },
+  }):sync()[1]
+end
+
+return M

--- a/lua/doodle/utils/formatutil.lua
+++ b/lua/doodle/utils/formatutil.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.trim(str)
+    return str:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+return M


### PR DESCRIPTION
A doodle note can exist within three scopes -

1. Project: Tied to the current project, shared between all Git branches
2. Branch: Specific to the current Git branch
3. Global: Available everywhere, shared across all projects