### PR TITLE
fix: update the bulk upsert query to be compatible with older sqlite versions

### DIFF
--- a/lua/doodle/utils/db_util.lua
+++ b/lua/doodle/utils/db_util.lua
@@ -87,7 +87,7 @@ function M.create_is_distinct(table_name, columns)
         if column ~= "created_at" and column ~= "updated_at" and column ~= "synced_at" then
             table.insert(
                 is_distinct,
-                ("%s.%s IS DISTINCT FROM excluded.%s"):format(table_name, column, column)
+                ("%s.%s != excluded.%s"):format(table_name, column, column)
             )
         end
     end


### PR DESCRIPTION
The `IS DISTINCT FROM` comparator was only added with sqlite 3.39.0. Replacing it with != for compatibility with older versions.