### PR TITLE
feat: add git_remote config option

### DIFF
--- a/lua/doodle/config.lua
+++ b/lua/doodle/config.lua
@@ -6,6 +6,7 @@ local Job = require("plenary.job")
 ---@field auto_save boolean
 ---@field sync boolean
 ---@field git_repo string
+---@field git_remote string
 ---@field hide_hint boolean
 ---@field project fun(): string
 ---@field branch fun(): string
@@ -31,6 +32,7 @@ function DoodleConfig.get_default()
         hide_hint = false,
         finder_height_factor = 0.4,
         finder_width_factor = 0.5,
+        git_remote = "origin main",
         project = function()
             return vim.fs.basename(vim.loop.cwd())
         end,

--- a/lua/doodle/sync/sync.lua
+++ b/lua/doodle/sync/sync.lua
@@ -49,7 +49,7 @@ local function ensure_repo(settings)
         vim.notify("Directory at " .. settings.git_repo .. " is not a Git Repository", vim.log.levels.ERROR)
     end
 
-    local ok = GitUtil.ensure_main(settings.git_repo)
+    local ok = GitUtil.ensure_main(settings.git_repo, settings.git_remote)
     if not ok then
         local oplog = repo:joinpath(oplog_file)
         if not oplog:exists() then
@@ -60,7 +60,7 @@ local function ensure_repo(settings)
             synclog:write("[]", "w")
         end
 
-        return GitUtil.push({ oplog_file, synclog }, "initial commit", settings.git_repo)
+        return GitUtil.push({ oplog_file, synclog }, "initial commit", settings.git_repo, settings.git_remote)
     end
 
     return true
@@ -172,7 +172,7 @@ end
 
 ---@return boolean
 function DoodleSync:pull()
-    local ok, err = GitUtil.pull(self.settings.git_repo)
+    local ok, err = GitUtil.pull(self.settings.git_repo, self.settings.git_remote)
     if not ok then
         vim.notify("Git rebase failed with error: " .. err)
         return false
@@ -291,7 +291,7 @@ function DoodleSync:push()
 
     local ok = GitUtil.push(files, ("<%s>%s: update directories=%s notes=%s blobs=%s")
         :format(now, self.config.device_id, #oplog.directory, #oplog.note, #oplog.blob),
-        self.settings.git_repo)
+        self.settings.git_repo, self.settings.git_remote)
 
     if ok then
         update_config(self.settings, self.config)

--- a/lua/doodle/utils/git_util.lua
+++ b/lua/doodle/utils/git_util.lua
@@ -3,11 +3,14 @@ local SyncUtil = require("doodle.utils.sync_util")
 local M = {}
 
 ---@param git_repo string
+---@param git_remote string
 ---@return boolean
-function M.ensure_main(git_repo)
+function M.ensure_main(git_repo, git_remote)
+    local remote_setting = vim.split(git_remote, " ")
+
     local ok, out = SyncUtil.run({
         "git",
-        "ls-remote", "--exit-code", "--heads", "origin", "main"
+        "ls-remote", "--exit-code", "--heads", remote_setting[0], remote_setting[1]
     }, git_repo)
 
     SyncUtil.run({
@@ -19,22 +22,27 @@ function M.ensure_main(git_repo)
 end
 
 ---@param git_repo string
+---@param git_remote string
 ---@return boolean
 ---@return string
-function M.pull(git_repo)
+function M.pull(git_repo, git_remote)
+    local remote_setting = vim.split(git_remote, " ")
+
     return SyncUtil.run({
         "git",
-        "pull", "--rebase", "origin", "main"
+        "pull", "--rebase", remote_setting[0], remote_setting[1]
     }, git_repo)
 end
 
 ---@param files string[]
 ---@param msg string
 ---@param git_repo string
+---@param git_remote string
 ---@return boolean
-function M.push(files, msg, git_repo)
+function M.push(files, msg, git_repo, git_remote)
     local ok = true
     local err = nil
+    local remote_setting = vim.split(git_remote, " ")
 
     ok, err = SyncUtil.run(vim.list_extend(
         { "git", "add" },
@@ -55,7 +63,7 @@ function M.push(files, msg, git_repo)
 
     ok, err = SyncUtil.run({
         "git",
-        "push", "origin", "main"
+        "push", remote_setting[0], remote_setting[1]
     }, git_repo)
 
     if not ok then

--- a/lua/doodle/utils/git_util.lua
+++ b/lua/doodle/utils/git_util.lua
@@ -8,15 +8,15 @@ local M = {}
 function M.ensure_main(git_repo, git_remote)
     local remote_setting = vim.split(git_remote, " ")
 
-    local ok, out = SyncUtil.run({
+    local ok, out = SyncUtil.run(vim.list_extend({
         "git",
-        "ls-remote", "--exit-code", "--heads", remote_setting[0], remote_setting[1]
-    }, git_repo)
+        "ls-remote", "--exit-code", "--heads"
+    }, remote_setting), git_repo)
 
-    SyncUtil.run({
+    SyncUtil.run(vim.list_extend({
         "git",
         "branch", "-M", "main"
-    }, git_repo)
+    }, remote_setting), git_repo)
 
     return ok
 end
@@ -28,10 +28,10 @@ end
 function M.pull(git_repo, git_remote)
     local remote_setting = vim.split(git_remote, " ")
 
-    return SyncUtil.run({
+    return SyncUtil.run(vim.list_extend({
         "git",
-        "pull", "--rebase", remote_setting[0], remote_setting[1]
-    }, git_repo)
+        "pull", "--rebase"
+    }, remote_setting), git_repo)
 end
 
 ---@param files string[]
@@ -61,10 +61,10 @@ function M.push(files, msg, git_repo, git_remote)
         return false
     end
 
-    ok, err = SyncUtil.run({
+    ok, err = SyncUtil.run(vim.list_extend({
         "git",
-        "push", remote_setting[0], remote_setting[1]
-    }, git_repo)
+        "push"
+    }, remote_setting), git_repo)
 
     if not ok then
         return false

--- a/lua/doodle/utils/git_util.lua
+++ b/lua/doodle/utils/git_util.lua
@@ -13,10 +13,10 @@ function M.ensure_main(git_repo, git_remote)
         "ls-remote", "--exit-code", "--heads"
     }, remote_setting), git_repo)
 
-    SyncUtil.run(vim.list_extend({
+    SyncUtil.run({
         "git",
-        "branch", "-M", "main"
-    }, remote_setting), git_repo)
+        "branch", "-M", remote_setting[2]
+    }, git_repo)
 
     return ok
 end


### PR DESCRIPTION
Simply adds a option to configure to a different git remote.

Covers cases where remote is not called `origin`, defaults to `origin main` if not set.

Closes #23